### PR TITLE
Implement user home screen

### DIFF
--- a/Teacher Workout.xcodeproj/project.pbxproj
+++ b/Teacher Workout.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		BB13A3A926BAAC4400E0A7D5 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3A826BAAC4400E0A7D5 /* HomeView.swift */; };
 		BB13A3AC26BAAD5A00E0A7D5 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3AB26BAAD5A00E0A7D5 /* HomeViewModel.swift */; };
+		BB13A3AF26BAB3B300E0A7D5 /* Lesson.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3AE26BAB3B300E0A7D5 /* Lesson.swift */; };
+		BB13A3B126BAB45500E0A7D5 /* LessonNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3B026BAB45500E0A7D5 /* LessonNode.swift */; };
+		BB13A3B326BABDC400E0A7D5 /* LessonItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3B226BABDC400E0A7D5 /* LessonItemCell.swift */; };
 		BB1F1CD7268701B400663EEC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1F1CD6268701B400663EEC /* AppDelegate.swift */; };
 		BB1F1CE3268701B500663EEC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BB1F1CE1268701B500663EEC /* LaunchScreen.storyboard */; };
 		BB1F1CEE268701B500663EEC /* Teacher_WorkoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1F1CED268701B500663EEC /* Teacher_WorkoutTests.swift */; };
@@ -108,6 +111,9 @@
 /* Begin PBXFileReference section */
 		BB13A3A826BAAC4400E0A7D5 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		BB13A3AB26BAAD5A00E0A7D5 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		BB13A3AE26BAB3B300E0A7D5 /* Lesson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson.swift; sourceTree = "<group>"; };
+		BB13A3B026BAB45500E0A7D5 /* LessonNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonNode.swift; sourceTree = "<group>"; };
+		BB13A3B226BABDC400E0A7D5 /* LessonItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonItemCell.swift; sourceTree = "<group>"; };
 		BB1F1CD3268701B400663EEC /* Teacher Workout.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Teacher Workout.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB1F1CD6268701B400663EEC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BB1F1CE2268701B500663EEC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -230,6 +236,14 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		BB13A3AD26BAB39E00E0A7D5 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				BB13A3AE26BAB3B300E0A7D5 /* Lesson.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		BB1F1CCA268701B400663EEC = {
 			isa = PBXGroup;
 			children = (
@@ -330,6 +344,7 @@
 			isa = PBXGroup;
 			children = (
 				BB38127726874F3E0008FDC6 /* Coordinator */,
+				BB13A3AD26BAB39E00E0A7D5 /* Model */,
 				BB38127826874F450008FDC6 /* View */,
 				BB13A3AA26BAAD4800E0A7D5 /* ViewModel */,
 			);
@@ -432,6 +447,7 @@
 			isa = PBXGroup;
 			children = (
 				BB13A3A826BAAC4400E0A7D5 /* HomeView.swift */,
+				BB13A3B226BABDC400E0A7D5 /* LessonItemCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -509,6 +525,7 @@
 			isa = PBXGroup;
 			children = (
 				BBC3A21F26B545E6009C6DDE /* ThemesNode.swift */,
+				BB13A3B026BAB45500E0A7D5 /* LessonNode.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -968,6 +985,7 @@
 				DE60B19D2687466300EB01F8 /* OnboardingHeroView.swift in Sources */,
 				BB13A3AC26BAAD5A00E0A7D5 /* HomeViewModel.swift in Sources */,
 				BBC3A21D26B5444E009C6DDE /* DiscoverViewModel.swift in Sources */,
+				BB13A3B326BABDC400E0A7D5 /* LessonItemCell.swift in Sources */,
 				DE943E24269D8EC700DD2EC3 /* CreateNewPasswordView.swift in Sources */,
 				DE60B19F2687476200EB01F8 /* OnboardingPageViewController.swift in Sources */,
 				DEDDCCAB269E22BE00E64AAE /* TrailingCloseButton.swift in Sources */,
@@ -988,6 +1006,7 @@
 				DE943E1B269D8CFC00DD2EC3 /* SignUpView.swift in Sources */,
 				BB7699AC26875430009DF26F /* SceneDelegate.swift in Sources */,
 				DE943E1D269D8D3800DD2EC3 /* SignInCoordinator.swift in Sources */,
+				BB13A3B126BAB45500E0A7D5 /* LessonNode.swift in Sources */,
 				DE85640426A0525A004A83BF /* LandingPageView.swift in Sources */,
 				BB38126C268749CC0008FDC6 /* MenuTabBarController.swift in Sources */,
 				BBC3A22226B54988009C6DDE /* DiscoverView.swift in Sources */,
@@ -995,6 +1014,7 @@
 				BB13A3A926BAAC4400E0A7D5 /* HomeView.swift in Sources */,
 				BBC3A21726B54418009C6DDE /* NetworkingConstants.swift in Sources */,
 				BB381284268751CD0008FDC6 /* ProfileViewController.swift in Sources */,
+				BB13A3AF26BAB3B300E0A7D5 /* Lesson.swift in Sources */,
 				BB29A3E7268772B60063C1A4 /* DiscoverCoordinator.swift in Sources */,
 				BBC3A21C26B5444E009C6DDE /* Theme.swift in Sources */,
 				BB29A3E9268773FC0063C1A4 /* HomeCoordinator.swift in Sources */,

--- a/Teacher Workout.xcodeproj/project.pbxproj
+++ b/Teacher Workout.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BB13A3A926BAAC4400E0A7D5 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3A826BAAC4400E0A7D5 /* HomeView.swift */; };
+		BB13A3AC26BAAD5A00E0A7D5 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3AB26BAAD5A00E0A7D5 /* HomeViewModel.swift */; };
 		BB1F1CD7268701B400663EEC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1F1CD6268701B400663EEC /* AppDelegate.swift */; };
 		BB1F1CE3268701B500663EEC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BB1F1CE1268701B500663EEC /* LaunchScreen.storyboard */; };
 		BB1F1CEE268701B500663EEC /* Teacher_WorkoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1F1CED268701B500663EEC /* Teacher_WorkoutTests.swift */; };
@@ -27,7 +29,6 @@
 		BB38126E26874C930008FDC6 /* ApplicationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB38126D26874C930008FDC6 /* ApplicationCoordinator.swift */; };
 		BB38127126874CFA0008FDC6 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB38127026874CFA0008FDC6 /* Coordinator.swift */; };
 		BB38127626874D7D0008FDC6 /* MenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB38127526874D7D0008FDC6 /* MenuCoordinator.swift */; };
-		BB381280268751940008FDC6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB38127F268751940008FDC6 /* HomeViewController.swift */; };
 		BB381284268751CD0008FDC6 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB381283268751CD0008FDC6 /* ProfileViewController.swift */; };
 		BB6E990A26B9DBCB007B44F9 /* ListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6E990926B9DBCB007B44F9 /* ListHeaderView.swift */; };
 		BB6E990C26B9DD35007B44F9 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6E990B26B9DD35007B44F9 /* SearchBar.swift */; };
@@ -105,6 +106,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BB13A3A826BAAC4400E0A7D5 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		BB13A3AB26BAAD5A00E0A7D5 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		BB1F1CD3268701B400663EEC /* Teacher Workout.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Teacher Workout.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB1F1CD6268701B400663EEC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BB1F1CE2268701B500663EEC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -132,7 +135,6 @@
 		BB38126D26874C930008FDC6 /* ApplicationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationCoordinator.swift; sourceTree = "<group>"; };
 		BB38127026874CFA0008FDC6 /* Coordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BB38127526874D7D0008FDC6 /* MenuCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCoordinator.swift; sourceTree = "<group>"; };
-		BB38127F268751940008FDC6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		BB381283268751CD0008FDC6 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		BB6E990926B9DBCB007B44F9 /* ListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListHeaderView.swift; sourceTree = "<group>"; };
 		BB6E990B26B9DD35007B44F9 /* SearchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
@@ -220,6 +222,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BB13A3AA26BAAD4800E0A7D5 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				BB13A3AB26BAAD5A00E0A7D5 /* HomeViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		BB1F1CCA268701B400663EEC = {
 			isa = PBXGroup;
 			children = (
@@ -321,6 +331,7 @@
 			children = (
 				BB38127726874F3E0008FDC6 /* Coordinator */,
 				BB38127826874F450008FDC6 /* View */,
+				BB13A3AA26BAAD4800E0A7D5 /* ViewModel */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -420,7 +431,7 @@
 		BB38127826874F450008FDC6 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				BB38127F268751940008FDC6 /* HomeViewController.swift */,
+				BB13A3A826BAAC4400E0A7D5 /* HomeView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -955,6 +966,7 @@
 				BB6E990C26B9DD35007B44F9 /* SearchBar.swift in Sources */,
 				DEDDCCB3269E2B5400E64AAE /* ProvidersView.swift in Sources */,
 				DE60B19D2687466300EB01F8 /* OnboardingHeroView.swift in Sources */,
+				BB13A3AC26BAAD5A00E0A7D5 /* HomeViewModel.swift in Sources */,
 				BBC3A21D26B5444E009C6DDE /* DiscoverViewModel.swift in Sources */,
 				DE943E24269D8EC700DD2EC3 /* CreateNewPasswordView.swift in Sources */,
 				DE60B19F2687476200EB01F8 /* OnboardingPageViewController.swift in Sources */,
@@ -980,9 +992,9 @@
 				BB38126C268749CC0008FDC6 /* MenuTabBarController.swift in Sources */,
 				BBC3A22226B54988009C6DDE /* DiscoverView.swift in Sources */,
 				BB38127126874CFA0008FDC6 /* Coordinator.swift in Sources */,
+				BB13A3A926BAAC4400E0A7D5 /* HomeView.swift in Sources */,
 				BBC3A21726B54418009C6DDE /* NetworkingConstants.swift in Sources */,
 				BB381284268751CD0008FDC6 /* ProfileViewController.swift in Sources */,
-				BB381280268751940008FDC6 /* HomeViewController.swift in Sources */,
 				BB29A3E7268772B60063C1A4 /* DiscoverCoordinator.swift in Sources */,
 				BBC3A21C26B5444E009C6DDE /* Theme.swift in Sources */,
 				BB29A3E9268773FC0063C1A4 /* HomeCoordinator.swift in Sources */,

--- a/Teacher Workout.xcodeproj/project.pbxproj
+++ b/Teacher Workout.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		BB13A3AF26BAB3B300E0A7D5 /* Lesson.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3AE26BAB3B300E0A7D5 /* Lesson.swift */; };
 		BB13A3B126BAB45500E0A7D5 /* LessonNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3B026BAB45500E0A7D5 /* LessonNode.swift */; };
 		BB13A3B326BABDC400E0A7D5 /* LessonItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3B226BABDC400E0A7D5 /* LessonItemCell.swift */; };
+		BB13A3B526BABF0800E0A7D5 /* LessonsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3B426BABF0800E0A7D5 /* LessonsList.swift */; };
+		BB13A3B726BABF8100E0A7D5 /* ThemesGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13A3B626BABF8100E0A7D5 /* ThemesGrid.swift */; };
 		BB1F1CD7268701B400663EEC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1F1CD6268701B400663EEC /* AppDelegate.swift */; };
 		BB1F1CE3268701B500663EEC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BB1F1CE1268701B500663EEC /* LaunchScreen.storyboard */; };
 		BB1F1CEE268701B500663EEC /* Teacher_WorkoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1F1CED268701B500663EEC /* Teacher_WorkoutTests.swift */; };
@@ -114,6 +116,8 @@
 		BB13A3AE26BAB3B300E0A7D5 /* Lesson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson.swift; sourceTree = "<group>"; };
 		BB13A3B026BAB45500E0A7D5 /* LessonNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonNode.swift; sourceTree = "<group>"; };
 		BB13A3B226BABDC400E0A7D5 /* LessonItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonItemCell.swift; sourceTree = "<group>"; };
+		BB13A3B426BABF0800E0A7D5 /* LessonsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonsList.swift; sourceTree = "<group>"; };
+		BB13A3B626BABF8100E0A7D5 /* ThemesGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesGrid.swift; sourceTree = "<group>"; };
 		BB1F1CD3268701B400663EEC /* Teacher Workout.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Teacher Workout.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB1F1CD6268701B400663EEC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BB1F1CE2268701B500663EEC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -448,6 +452,7 @@
 			children = (
 				BB13A3A826BAAC4400E0A7D5 /* HomeView.swift */,
 				BB13A3B226BABDC400E0A7D5 /* LessonItemCell.swift */,
+				BB13A3B426BABF0800E0A7D5 /* LessonsList.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -485,6 +490,7 @@
 			children = (
 				BBC3A22126B54988009C6DDE /* DiscoverView.swift */,
 				BBC3A22326B55BAC009C6DDE /* ThemeItemCell.swift */,
+				BB13A3B626BABF8100E0A7D5 /* ThemesGrid.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -975,6 +981,7 @@
 				DECD7A0D269F1179004FE9E3 /* Validator.swift in Sources */,
 				DE60B1CC26875F9F00EB01F8 /* OnboardingPage.swift in Sources */,
 				DEDDCCB1269E292F00E64AAE /* Text+Styling.swift in Sources */,
+				BB13A3B526BABF0800E0A7D5 /* LessonsList.swift in Sources */,
 				DEDDCCB7269E2C3C00E64AAE /* SignInFormView.swift in Sources */,
 				DE60B1A226874A2700EB01F8 /* NSObject+Extensions.swift in Sources */,
 				DE96A06D26B545E40071188D /* SignUpFormViewModel.swift in Sources */,
@@ -1023,6 +1030,7 @@
 				DE4B86CD269DBEC100D7636E /* InputFieldView.swift in Sources */,
 				BB38126E26874C930008FDC6 /* ApplicationCoordinator.swift in Sources */,
 				BBC3A21626B54418009C6DDE /* APIError.swift in Sources */,
+				BB13A3B726BABF8100E0A7D5 /* ThemesGrid.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Teacher Workout/AppDelegate/AppDelegate.swift
+++ b/Teacher Workout/AppDelegate/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UITabBar.appearance().tintColor = accentColor
         UITabBar.appearance().unselectedItemTintColor = UIColor(named: "secondaryColor")
 
-        UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: accentColor]
-        UINavigationBar.appearance().titleTextAttributes = [.foregroundColor: accentColor]
+        UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: accentColor, .font: UIFont(name: "Mulish-Bold", size: 32)!]
+        UINavigationBar.appearance().titleTextAttributes = [.foregroundColor: accentColor, .font: UIFont(name: "Mulish-SemiBold", size: 18)!]
     }
 }

--- a/Teacher Workout/Components/General/SearchBar.swift
+++ b/Teacher Workout/Components/General/SearchBar.swift
@@ -10,7 +10,7 @@ struct SearchBar: View {
             TextField(AppStrings.Search.placeholder.localized(), text: $text)
                 .foregroundColor(Color("AccentColor"))
                 .font(Font.custom("Mulish-SemiBold", size: 16))
-                .frame(height: 40)
+                .frame(height: 34)
                 .padding(7)
                 .padding(.horizontal, 25)
                 .background(Color(.white))

--- a/Teacher Workout/Components/General/SearchBar.swift
+++ b/Teacher Workout/Components/General/SearchBar.swift
@@ -10,7 +10,7 @@ struct SearchBar: View {
             TextField(AppStrings.Search.placeholder.localized(), text: $text)
                 .foregroundColor(Color("AccentColor"))
                 .font(Font.custom("Mulish-SemiBold", size: 16))
-                .frame(height: 48)
+                .frame(height: 40)
                 .padding(7)
                 .padding(.horizontal, 25)
                 .background(Color(.white))

--- a/Teacher Workout/Features/Discover/View/DiscoverView.swift
+++ b/Teacher Workout/Features/Discover/View/DiscoverView.swift
@@ -10,14 +10,7 @@ struct DiscoverView: View {
 
             ListHeaderView(label: AppStrings.Discover.listDescription.localized())
 
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 15)], spacing: 15) {
-                ForEach(viewModel.themes) { theme in
-                    ThemeItemCell(item: theme)
-                        .frame(maxHeight: 57)
-                }
-            }
-            .padding(.horizontal, 16)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            ThemesGrid(themes: viewModel.themes)
         }
         .navigationBarTitle(AppStrings.Discover.navigationTitle.localized(),
                             displayMode: .large)

--- a/Teacher Workout/Features/Discover/View/ThemesGrid.swift
+++ b/Teacher Workout/Features/Discover/View/ThemesGrid.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ThemesGrid: View {
+    var themes: [Theme]
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 15)], spacing: 15) {
+            ForEach(themes) { theme in
+                ThemeItemCell(item: theme)
+                    .frame(maxHeight: 57)
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/Teacher Workout/Features/Home/Coordinator/HomeCoordinator.swift
+++ b/Teacher Workout/Features/Home/Coordinator/HomeCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import UIKit
 
 final class HomeCoordinator: NSObject, Coordinator {
@@ -6,10 +7,10 @@ final class HomeCoordinator: NSObject, Coordinator {
     var navigationController: UINavigationController
 
     override init() {
-        let viewController = HomeViewController()
+        let viewController = UIHostingController(rootView: HomeView())
         viewController.tabBarItem.title = AppStrings.Menu.home.localized()
         viewController.tabBarItem.image = UIImage(systemName: "house")
         navigationController = UINavigationController(rootViewController: viewController)
-        navigationController.setNavigationBarHidden(true, animated: false)
+        navigationController.navigationBar.prefersLargeTitles = true
     }
 }

--- a/Teacher Workout/Features/Home/Model/Lesson.swift
+++ b/Teacher Workout/Features/Home/Model/Lesson.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Lesson: Identifiable {
+    let id: String
+    let title: String
+    let imageURL: String?
+    let themeTitle: String
+    let duration: String
+}

--- a/Teacher Workout/Features/Home/View/HomeView.swift
+++ b/Teacher Workout/Features/Home/View/HomeView.swift
@@ -10,7 +10,25 @@ struct HomeView: View {
 
             ListHeaderView(label: AppStrings.Home.lessonsInProgress.localized())
 
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 290), spacing: 15)], spacing: 15) {
+                ForEach(viewModel.inProgressLessons) { lesson in
+                    LessonItemCell(item: lesson)
+                        .frame(maxHeight: 74)
+                }
+            }
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+
             ListHeaderView(label: AppStrings.Home.newLessons.localized())
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 290), spacing: 15)], spacing: 15) {
+                ForEach(viewModel.newLessons) { lesson in
+                    LessonItemCell(item: lesson)
+                        .frame(maxHeight: 74)
+                }
+            }
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 
             ListHeaderView(label: AppStrings.Discover.listDescription.localized())
 
@@ -27,6 +45,7 @@ struct HomeView: View {
                             displayMode: .large)
         .onAppear {
             viewModel.loadThemes()
+            viewModel.loadLessons()
         }
     }
 }

--- a/Teacher Workout/Features/Home/View/HomeView.swift
+++ b/Teacher Workout/Features/Home/View/HomeView.swift
@@ -10,36 +10,15 @@ struct HomeView: View {
 
             ListHeaderView(label: AppStrings.Home.lessonsInProgress.localized())
 
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 290), spacing: 15)], spacing: 15) {
-                ForEach(viewModel.inProgressLessons) { lesson in
-                    LessonItemCell(item: lesson)
-                        .frame(maxHeight: 74)
-                }
-            }
-            .padding(.horizontal, 16)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            LessonsList(lessons: viewModel.inProgressLessons)
 
             ListHeaderView(label: AppStrings.Home.newLessons.localized())
 
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 290), spacing: 15)], spacing: 15) {
-                ForEach(viewModel.newLessons) { lesson in
-                    LessonItemCell(item: lesson)
-                        .frame(maxHeight: 74)
-                }
-            }
-            .padding(.horizontal, 16)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            LessonsList(lessons: viewModel.newLessons)
 
             ListHeaderView(label: AppStrings.Discover.listDescription.localized())
 
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 15)], spacing: 15) {
-                ForEach(viewModel.themes) { theme in
-                    ThemeItemCell(item: theme)
-                        .frame(maxHeight: 57)
-                }
-            }
-            .padding(.horizontal, 16)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            ThemesGrid(themes: viewModel.themes)
         }
         .navigationBarTitle(AppStrings.Home.navigationTitle.localized(),
                             displayMode: .large)

--- a/Teacher Workout/Features/Home/View/HomeView.swift
+++ b/Teacher Workout/Features/Home/View/HomeView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject var viewModel = HomeViewModel()
+
+    var body: some View {
+        ScrollView {
+            SearchBar(text: $viewModel.searchText)
+                .padding(.top, 16)
+
+            ListHeaderView(label: AppStrings.Home.lessonsInProgress.localized())
+
+            ListHeaderView(label: AppStrings.Home.newLessons.localized())
+
+            ListHeaderView(label: AppStrings.Discover.listDescription.localized())
+        }
+        .navigationBarTitle(AppStrings.Home.navigationTitle.localized(),
+                            displayMode: .large)
+    }
+}

--- a/Teacher Workout/Features/Home/View/HomeView.swift
+++ b/Teacher Workout/Features/Home/View/HomeView.swift
@@ -19,6 +19,8 @@ struct HomeView: View {
             ListHeaderView(label: AppStrings.Discover.listDescription.localized())
 
             ThemesGrid(themes: viewModel.themes)
+
+            Spacer(minLength: 30)
         }
         .navigationBarTitle(AppStrings.Home.navigationTitle.localized(),
                             displayMode: .large)

--- a/Teacher Workout/Features/Home/View/HomeView.swift
+++ b/Teacher Workout/Features/Home/View/HomeView.swift
@@ -13,8 +13,20 @@ struct HomeView: View {
             ListHeaderView(label: AppStrings.Home.newLessons.localized())
 
             ListHeaderView(label: AppStrings.Discover.listDescription.localized())
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 15)], spacing: 15) {
+                ForEach(viewModel.themes) { theme in
+                    ThemeItemCell(item: theme)
+                        .frame(maxHeight: 57)
+                }
+            }
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
         .navigationBarTitle(AppStrings.Home.navigationTitle.localized(),
                             displayMode: .large)
+        .onAppear {
+            viewModel.loadThemes()
+        }
     }
 }

--- a/Teacher Workout/Features/Home/View/HomeViewController.swift
+++ b/Teacher Workout/Features/Home/View/HomeViewController.swift
@@ -1,8 +1,0 @@
-import UIKit
-
-class HomeViewController: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .red
-    }
-}

--- a/Teacher Workout/Features/Home/View/LessonItemCell.swift
+++ b/Teacher Workout/Features/Home/View/LessonItemCell.swift
@@ -1,0 +1,27 @@
+import Kingfisher
+import SwiftUI
+
+struct LessonItemCell: View {
+    var item: Lesson
+
+    var body: some View {
+        HStack(spacing: 15) {
+            if let imageName = item.imageURL {
+                KFImage(URL(string: imageName))
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 48, height: 74)
+                    .clipped()
+            }
+
+            Text(item.title)
+                .font(Font.custom("Mulish-Regular", size: 14))
+            Spacer()
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color("AccentColor"), lineWidth: 0.5)
+        )
+    }
+}

--- a/Teacher Workout/Features/Home/View/LessonItemCell.swift
+++ b/Teacher Workout/Features/Home/View/LessonItemCell.swift
@@ -14,8 +14,19 @@ struct LessonItemCell: View {
                     .clipped()
             }
 
-            Text(item.title)
-                .font(Font.custom("Mulish-Regular", size: 14))
+            VStack(alignment: .leading, spacing: 5) {
+                Text(item.title)
+                    .font(Font.custom("Mulish-Regular", size: 14))
+
+                Text(item.themeTitle)
+                    .foregroundColor(Color("AccentColor"))
+                    .font(Font.custom("Mulish-SemiBold", size: 12))
+
+                HStack(spacing: 4) {
+                    Image(systemName: "clock")
+                    Text(item.duration)
+                }.font(Font.custom("Mulish-SemiBold", size: 12))
+            }
             Spacer()
         }
         .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/Teacher Workout/Features/Home/View/LessonsList.swift
+++ b/Teacher Workout/Features/Home/View/LessonsList.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct LessonsList: View {
+    var lessons: [Lesson]
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 290), spacing: 15)], spacing: 15) {
+            ForEach(lessons) { lesson in
+                LessonItemCell(item: lesson)
+                    .frame(maxHeight: 74)
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/Teacher Workout/Features/Home/ViewModel/HomeViewModel.swift
+++ b/Teacher Workout/Features/Home/ViewModel/HomeViewModel.swift
@@ -2,6 +2,8 @@ import Foundation
 
 final class HomeViewModel: ObservableObject {
     @Published var themes: [Theme] = []
+    @Published var newLessons: [Lesson] = []
+    @Published var inProgressLessons: [Lesson] = []
 
     var searchText = ""
 
@@ -17,6 +19,20 @@ final class HomeViewModel: ObservableObject {
             switch result {
             case let .success(value):
                 self.themes = value
+            default:
+                break
+            }
+        }
+    }
+
+    func loadLessons() {
+        dataProvider.getLessons { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case let .success(value):
+                // TODO: Get proper data from API when ready
+                self.inProgressLessons = Array(value.prefix(upTo: 2))
+                self.newLessons = Array(value.suffix(3))
             default:
                 break
             }

--- a/Teacher Workout/Features/Home/ViewModel/HomeViewModel.swift
+++ b/Teacher Workout/Features/Home/ViewModel/HomeViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class HomeViewModel: ObservableObject {
+    var searchText = ""
+}

--- a/Teacher Workout/Features/Home/ViewModel/HomeViewModel.swift
+++ b/Teacher Workout/Features/Home/ViewModel/HomeViewModel.swift
@@ -1,5 +1,25 @@
 import Foundation
 
 final class HomeViewModel: ObservableObject {
+    @Published var themes: [Theme] = []
+
     var searchText = ""
+
+    private let dataProvider: DataProviderProtocol
+
+    init(dataProvider: DataProviderProtocol = Config.dataService) {
+        self.dataProvider = dataProvider
+    }
+
+    func loadThemes() {
+        dataProvider.getThemes { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case let .success(value):
+                self.themes = value
+            default:
+                break
+            }
+        }
+    }
 }

--- a/Teacher Workout/Localization/AppStrings.swift
+++ b/Teacher Workout/Localization/AppStrings.swift
@@ -66,4 +66,10 @@ enum AppStrings: String, Localizable {
         case placeholder = "Search.placeholder"
         case cancelButton = "Search.cancelButton"
     }
+
+    enum Home: String, Localizable {
+        case navigationTitle = "Home.navigationTitle"
+        case lessonsInProgress = "Home.lessonsInProgress"
+        case newLessons = "Home.newLessons"
+    }
 }

--- a/Teacher Workout/Localization/en.lproj/Localizable.strings
+++ b/Teacher Workout/Localization/en.lproj/Localizable.strings
@@ -43,3 +43,9 @@
 "Search.placeholder" = "Find a topic";
 
 "Search.cancelButton" = "Cancel";
+
+"Home.navigationTitle" = "Find a lesson";
+
+"Home.lessonsInProgress" = "Lessons in progress";
+
+"Home.newLessons" = "Newly added lessons";

--- a/Teacher Workout/Localization/ro.lproj/Localizable.strings
+++ b/Teacher Workout/Localization/ro.lproj/Localizable.strings
@@ -43,3 +43,9 @@
 "Search.placeholder" = "Caută un subiect";
 
 "Search.cancelButton" = "Anulează";
+
+"Home.navigationTitle" = "Caută o lecție";
+
+"Home.lessonsInProgress" = "Lecții în curs";
+
+"Home.newLessons" = "Lecții nou adăugate";

--- a/Teacher Workout/NetworkingLayer/APIService/DataProviderProtocol.swift
+++ b/Teacher Workout/NetworkingLayer/APIService/DataProviderProtocol.swift
@@ -2,4 +2,5 @@ import Foundation
 
 protocol DataProviderProtocol {
     func getThemes(completion: @escaping (Result<[Theme], Error>) -> Void)
+    func getLessons(completion: @escaping (Result<[Lesson], Error>) -> Void)
 }

--- a/Teacher Workout/NetworkingLayer/GraphQL/API.swift
+++ b/Teacher Workout/NetworkingLayer/GraphQL/API.swift
@@ -8,7 +8,7 @@ public final class LessonsQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
   public let operationDefinition: String =
     """
-    query Lessons($themeId: ID!) {
+    query Lessons($themeId: ID) {
       lessons(themeId: $themeId) {
         __typename
         edges {
@@ -17,6 +17,15 @@ public final class LessonsQuery: GraphQLQuery {
             __typename
             id
             title
+            thumbnail {
+              __typename
+              url
+              description
+            }
+            theme {
+              __typename
+              title
+            }
             duration {
               __typename
               displayValue
@@ -29,9 +38,9 @@ public final class LessonsQuery: GraphQLQuery {
 
   public let operationName: String = "Lessons"
 
-  public var themeId: GraphQLID
+  public var themeId: GraphQLID?
 
-  public init(themeId: GraphQLID) {
+  public init(themeId: GraphQLID? = nil) {
     self.themeId = themeId
   }
 
@@ -153,6 +162,8 @@ public final class LessonsQuery: GraphQLQuery {
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("id", type: .scalar(GraphQLID.self)),
               GraphQLField("title", type: .nonNull(.scalar(String.self))),
+              GraphQLField("thumbnail", type: .nonNull(.object(Thumbnail.selections))),
+              GraphQLField("theme", type: .nonNull(.object(Theme.selections))),
               GraphQLField("duration", type: .nonNull(.object(Duration.selections))),
             ]
           }
@@ -163,8 +174,8 @@ public final class LessonsQuery: GraphQLQuery {
             self.resultMap = unsafeResultMap
           }
 
-          public init(id: GraphQLID? = nil, title: String, duration: Duration) {
-            self.init(unsafeResultMap: ["__typename": "Lesson", "id": id, "title": title, "duration": duration.resultMap])
+          public init(id: GraphQLID? = nil, title: String, thumbnail: Thumbnail, theme: Theme, duration: Duration) {
+            self.init(unsafeResultMap: ["__typename": "Lesson", "id": id, "title": title, "thumbnail": thumbnail.resultMap, "theme": theme.resultMap, "duration": duration.resultMap])
           }
 
           public var __typename: String {
@@ -195,6 +206,26 @@ public final class LessonsQuery: GraphQLQuery {
             }
           }
 
+          /// The thumbnail of the Lesson
+          public var thumbnail: Thumbnail {
+            get {
+              return Thumbnail(unsafeResultMap: resultMap["thumbnail"]! as! ResultMap)
+            }
+            set {
+              resultMap.updateValue(newValue.resultMap, forKey: "thumbnail")
+            }
+          }
+
+          /// The Theme of the Lesson
+          public var theme: Theme {
+            get {
+              return Theme(unsafeResultMap: resultMap["theme"]! as! ResultMap)
+            }
+            set {
+              resultMap.updateValue(newValue.resultMap, forKey: "theme")
+            }
+          }
+
           /// The duration of the Lesson
           public var duration: Duration {
             get {
@@ -202,6 +233,97 @@ public final class LessonsQuery: GraphQLQuery {
             }
             set {
               resultMap.updateValue(newValue.resultMap, forKey: "duration")
+            }
+          }
+
+          public struct Thumbnail: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Image"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("url", type: .nonNull(.scalar(String.self))),
+                GraphQLField("description", type: .nonNull(.scalar(String.self))),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public init(url: String, description: String) {
+              self.init(unsafeResultMap: ["__typename": "Image", "url": url, "description": description])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// URL to the image.
+            public var url: String {
+              get {
+                return resultMap["url"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "url")
+              }
+            }
+
+            /// Image description for accessibility.
+            public var description: String {
+              get {
+                return resultMap["description"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "description")
+              }
+            }
+          }
+
+          public struct Theme: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Theme"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("title", type: .nonNull(.scalar(String.self))),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public init(title: String) {
+              self.init(unsafeResultMap: ["__typename": "Theme", "title": title])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// The title of the Theme
+            public var title: String {
+              get {
+                return resultMap["title"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "title")
+              }
             }
           }
 

--- a/Teacher Workout/NetworkingLayer/GraphQL/GraphAPIService.swift
+++ b/Teacher Workout/NetworkingLayer/GraphQL/GraphAPIService.swift
@@ -41,6 +41,30 @@ class GraphAPIService: DataProviderProtocol {
             }
         }
     }
+
+    func getLessons(completion: @escaping (Result<[Lesson], Error>) -> Void) {
+        let query = LessonsQuery()
+        apolloClient.fetch(query: query) { result in
+            switch result {
+            case let .failure(error):
+                let queryResult = Result<[Lesson], Error>.failure(error)
+                completion(queryResult)
+            case let .success(value):
+                guard let themesResponse = value.data?.lessons?.edges else {
+                    let queryResult = Result<[Lesson], Error>.failure(APIError.invalidContent)
+                    completion(queryResult)
+                    return
+                }
+
+                let themesQueryResponse = themesResponse.compactMap { edge in
+                    Lesson(lessonNode: edge?.node)
+                }
+
+                let queryResult = Result<[Lesson], Error>.success(themesQueryResponse)
+                completion(queryResult)
+            }
+        }
+    }
 }
 
 class NetworkInterceptorProvider: DefaultInterceptorProvider {

--- a/Teacher Workout/NetworkingLayer/GraphQL/LessonsQuery.graphql
+++ b/Teacher Workout/NetworkingLayer/GraphQL/LessonsQuery.graphql
@@ -1,13 +1,20 @@
-query Lessons($themeId: ID!) {
+query Lessons($themeId: ID) {
   lessons(themeId: $themeId) {
    edges {
       node {
         id,
         title,
+        thumbnail {
+          url,
+          description
+        }
+        theme {
+          title
+        }
         duration {
             displayValue
-            }
         }
+      }
     }
   }
 }

--- a/Teacher Workout/NetworkingLayer/GraphQL/Model/LessonNode.swift
+++ b/Teacher Workout/NetworkingLayer/GraphQL/Model/LessonNode.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+typealias LessonNode = LessonsQuery.Data.Lesson.Edge.Node
+
+extension Lesson {
+    init?(lessonNode: LessonNode?) {
+        guard let lesson = lessonNode else {
+            return nil
+        }
+
+        id = lesson.id ?? UUID().uuidString
+        title = lesson.title
+        imageURL = lesson.thumbnail.url
+        duration = lesson.duration.displayValue
+        themeTitle = lesson.theme.title
+    }
+}


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #9  

<!-- Please mention the main changes this PR brings. -->

With this PR I implemented the home screen. On home, we have a navigation title, search bar, in-progress lessons, newly added lessons and lesson themes.
At the moment for in-progress and newly added lessons we use data from our API, but some mocked ones.
For search I implemented just the UI, the API integration should be done when API is ready.

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-04 at 15 46 19](https://user-images.githubusercontent.com/481425/128183022-720d21a3-e76b-4d66-a7cd-59dda4aef3fb.png)

