### PR TITLE
Fix cells tap detection

### DIFF
--- a/Teacher Workout/Assets.xcassets/Colors/backgroundColor.colorset/Contents.json
+++ b/Teacher Workout/Assets.xcassets/Colors/backgroundColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Teacher Workout/Features/Discover/View/ThemeItemCell.swift
+++ b/Teacher Workout/Features/Discover/View/ThemeItemCell.swift
@@ -18,6 +18,7 @@ struct ThemeItemCell: View {
                 .font(Font.custom("Mulish-Regular", size: 14))
             Spacer()
         }
+        .background(Color("backgroundColor"))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(
             RoundedRectangle(cornerRadius: 8)

--- a/Teacher Workout/Features/Home/View/LessonItemCell.swift
+++ b/Teacher Workout/Features/Home/View/LessonItemCell.swift
@@ -29,6 +29,7 @@ struct LessonItemCell: View {
             }
             Spacer()
         }
+        .background(Color("backgroundColor"))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(
             RoundedRectangle(cornerRadius: 8)


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #41  

Fix for tap detection on cells

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->

1. Run the app
2. Go to Home / Discover
3. Tap on a theme or lesson cell on the right empty space
4. Check the details screen is open