### PR TITLE
Add password error message.

### DIFF
--- a/Teacher Workout/Components/Form/InputFieldView.swift
+++ b/Teacher Workout/Components/Form/InputFieldView.swift
@@ -39,6 +39,7 @@ struct InputFieldView: View {
                showError {
                 Text(error)
                     .font(Font.custom("Mulish-Regular", size: 16))
+                    .fixedSize(horizontal: false, vertical: true)
                     .foregroundColor(.red)
             }
         }

--- a/Teacher Workout/Components/General/ExistingAccountFooterView.swift
+++ b/Teacher Workout/Components/General/ExistingAccountFooterView.swift
@@ -9,14 +9,14 @@ struct ExistingAccountFooterView: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            Text(AppStrings.Authentication.alreadyHaveAccountLabel.rawValue.localized())
+            Text(AppStrings.Authentication.alreadyHaveAccountLabel.localized())
                 .font(Font.custom("Mulish-SemiBold", size: 16))
                 .foregroundColor(.gray)
 
             Button(action: {
                 self.delegate.existingAccountFooterViewDidTapSignIn(self)
             }, label: {
-                Text(AppStrings.Authentication.signInButtonTitle.rawValue.localized())
+                Text(AppStrings.Authentication.signInButtonTitle.localized())
                     .font(Font.custom("Mulish-Bold", size: 16))
             })
         }

--- a/Teacher Workout/Features/Authentication/SignIn/View/SignInFormView.swift
+++ b/Teacher Workout/Features/Authentication/SignIn/View/SignInFormView.swift
@@ -11,17 +11,18 @@ struct SignInFormView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            InputFieldView(label: AppStrings.Authentication.Email.inputLabel.rawValue.localized(),
+            InputFieldView(label: AppStrings.Authentication.Email.inputLabel.localized(),
                            iconName: "envelope",
-                           placeholder: AppStrings.Authentication.Email.inputPlaceholder.rawValue.localized(),
-                           errorMessage: AppStrings.Authentication.Email.invalidEmailMessage.rawValue.localized(),
+                           placeholder: AppStrings.Authentication.Email.inputPlaceholder.localized(),
+                           errorMessage: AppStrings.Authentication.Email.invalidEmailMessage.localized(),
                            fieldData: $viewModel.email,
                            showError: $viewModel.showEmailError)
 
-            InputFieldView(label: AppStrings.Authentication.Password.inputLabel.rawValue.localized(),
+            InputFieldView(label: AppStrings.Authentication.Password.inputLabel.localized(),
                            iconName: "lock",
-                           placeholder: AppStrings.Authentication.Password.inputPlaceholder.rawValue.localized(),
+                           placeholder: AppStrings.Authentication.Password.inputPlaceholder.localized(),
                            isSecureField: true,
+                           errorMessage: AppStrings.Authentication.Password.invalidMessage.localized(),
                            fieldData: $viewModel.password,
                            showError: $viewModel.showPasswordError)
 
@@ -29,7 +30,7 @@ struct SignInFormView: View {
                 self.delegate.signInFormViewDidTapForgotPassword(self)
             }, label: {
                 VStack {
-                    Text(AppStrings.Authentication.signInForgotPasswordLabel.rawValue.localized())
+                    Text(AppStrings.Authentication.signInForgotPasswordLabel.localized())
                         .font(Font.custom("Mulish-Bold", size: 16))
                         .foregroundColor(.accentColor)
                 }
@@ -45,7 +46,7 @@ struct SignInFormView: View {
                 // TODO: Implement sign in action
                 self.delegate.signInFormViewDidTapSignIn(self)
             }, label: {
-                Text(AppStrings.Authentication.signInButtonTitle.rawValue.localized())
+                Text(AppStrings.Authentication.signInButtonTitle.localized())
                     .primaryButtonStyle()
             })
         }

--- a/Teacher Workout/Features/Authentication/SignIn/View/SignInView.swift
+++ b/Teacher Workout/Features/Authentication/SignIn/View/SignInView.swift
@@ -17,13 +17,13 @@ struct SignInView: View {
                     self.delegate.signInViewDidTapClose(self)
                 }
 
-                Text(AppStrings.Authentication.signInIntro.rawValue.localized())
+                Text(AppStrings.Authentication.signInIntro.localized())
                     .largeTitleStyle()
                     .padding(.bottom)
 
                 SignInFormView(viewModel: viewModel, delegate: self)
 
-                CustomDividerView(label: AppStrings.dividerLabel.rawValue.localized(), spacing: 10)
+                CustomDividerView(label: AppStrings.dividerLabel.localized(), spacing: 10)
                 ProvidersView()
                 Spacer()
             }

--- a/Teacher Workout/Features/Authentication/SignUp/View/SignUpFormView.swift
+++ b/Teacher Workout/Features/Authentication/SignUp/View/SignUpFormView.swift
@@ -10,23 +10,24 @@ struct SignUpFormView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            InputFieldView(label: AppStrings.Authentication.Email.inputLabel.rawValue.localized(),
+            InputFieldView(label: AppStrings.Authentication.Email.inputLabel.localized(),
                            iconName: "envelope",
-                           placeholder: AppStrings.Authentication.Email.inputPlaceholder.rawValue.localized(),
-                           errorMessage: AppStrings.Authentication.Email.invalidEmailMessage.rawValue.localized(),
+                           placeholder: AppStrings.Authentication.Email.inputPlaceholder.localized(),
+                           errorMessage: AppStrings.Authentication.Email.invalidEmailMessage.localized(),
                            fieldData: $viewModel.email,
                            showError: $viewModel.showEmailError)
 
-            InputFieldView(label: AppStrings.Authentication.Password.inputLabel.rawValue.localized(),
+            InputFieldView(label: AppStrings.Authentication.Password.inputLabel.localized(),
                            iconName: "lock",
-                           placeholder: AppStrings.Authentication.Password.inputPlaceholder.rawValue.localized(),
+                           placeholder: AppStrings.Authentication.Password.inputPlaceholder.localized(),
                            isSecureField: true,
+                           errorMessage: AppStrings.Authentication.Password.invalidMessage.localized(),
                            fieldData: $viewModel.password,
                            showError: $viewModel.showPasswordError)
 
             InputFieldView(label: AppStrings.Authentication.Password.inputConfirmLabel.localized(),
                            iconName: "lock",
-                           placeholder: AppStrings.Authentication.Password.inputPlaceholder.rawValue.localized(),
+                           placeholder: AppStrings.Authentication.Password.inputPlaceholder.localized(),
                            isSecureField: true,
                            fieldData: $viewModel.confirmPassword,
                            showError: $viewModel.showConfirmPasswordError)

--- a/Teacher Workout/Features/Authentication/SignUp/View/SignUpView.swift
+++ b/Teacher Workout/Features/Authentication/SignUp/View/SignUpView.swift
@@ -23,7 +23,7 @@ struct SignUpView: View {
 
                         SignUpFormView(delegate: self)
 
-                        CustomDividerView(label: AppStrings.dividerLabel.rawValue.localized(), spacing: 10)
+                        CustomDividerView(label: AppStrings.dividerLabel.localized(), spacing: 10)
                         ProvidersView()
                             .padding(.bottom, 20)
                         ExistingAccountFooterView(delegate: self)

--- a/Teacher Workout/Features/LandingPage/View/LandingPageView.swift
+++ b/Teacher Workout/Features/LandingPage/View/LandingPageView.swift
@@ -24,7 +24,7 @@ struct LandingPageView: View {
                     Button(action: {
                         self.delegate.landingPageViewDidTapSignUp(self)
                     }, label: {
-                        Text(AppStrings.Authentication.signUpButtonTitle.rawValue.localized())
+                        Text(AppStrings.Authentication.signUpButtonTitle.localized())
                             .primaryButtonStyle()
                     })
 

--- a/Teacher Workout/Features/Lessons/View/LessonIntroView.swift
+++ b/Teacher Workout/Features/Lessons/View/LessonIntroView.swift
@@ -48,7 +48,7 @@ struct LessonIntroView: View {
                     self.viewModel.saveLesson(lessonId: lesson.id)
                     self.delegate?.lessonIntroViewDidTapStartLesson(self)
                 }, label: {
-                    Text(AppStrings.Lesson.Intro.startLesson.rawValue.localized())
+                    Text(AppStrings.Lesson.Intro.startLesson.localized())
                         .primaryButtonStyle()
                         .padding()
                 })
@@ -56,7 +56,7 @@ struct LessonIntroView: View {
                     self.viewModel.saveLesson(lessonId: lesson.id)
                     self.delegate?.lessonIntroViewDidTapSaveLesson(self)
                 }, label: {
-                    Text(AppStrings.Lesson.Intro.saveLesson.rawValue.localized())
+                    Text(AppStrings.Lesson.Intro.saveLesson.localized())
                         .secondaryButtonStyle()
                         .padding(.horizontal)
                 })

--- a/Teacher Workout/Localization/AppStrings.swift
+++ b/Teacher Workout/Localization/AppStrings.swift
@@ -54,6 +54,7 @@ enum AppStrings: String, Localizable {
             case inputLabel = "Authentication.Password.inputLabel"
             case inputConfirmLabel = "Authentication.Password.inputConfirmLabel"
             case inputPlaceholder = "Authentication.Password.inputPlaceholder"
+            case invalidMessage = "Authentication.Password.invalidMessage"
         }
     }
 

--- a/Teacher Workout/Localization/en.lproj/Localizable.strings
+++ b/Teacher Workout/Localization/en.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 
 "Authentication.Password.inputPlaceholder" = "password";
 
+"Authentication.Password.invalidMessage" = "Your password should contain at least 1 lowercase letter, an uppercase letter, a number and it should be between 8-15 characters long.";
+
 "Discover.navigationTitle" = "Discover lessons";
 
 "Discover.listDescription" = "Lesson categories";

--- a/Teacher Workout/Localization/ro.lproj/Localizable.strings
+++ b/Teacher Workout/Localization/ro.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 
 "Authentication.Password.inputPlaceholder" = "parola";
 
+"Authentication.Password.invalidMessage" = "Parola trebuie să conțină cel puțin o literă mică, o literă majusculă, un număr și să aibă o lungime între 8 și 5 caractere.";
+
 "Discover.navigationTitle" = "Descoperă lecțiile";
 
 "Discover.listDescription" = "Categorii de lecții";


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #39 

With this PR, I added a password field error message. 

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->

1. Run the iOS app
2. Tap Sign in
3. Enter a valid email
4. Enter an invalid email
5. Tap SIGN IN
6. Check a password error message is displayed

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-28 at 16 01 51](https://user-images.githubusercontent.com/481425/131218825-0befa3af-b0de-469b-8113-7d53a7162be3.png)

