### PR TITLE
Fix intro lesson screen layout

### DIFF
--- a/Teacher Workout/Components/Modifiers/Fonts.swift
+++ b/Teacher Workout/Components/Modifiers/Fonts.swift
@@ -24,14 +24,16 @@ extension View {
 struct BoldLargeFont: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .scaledFont(name: "Mulish-Bold", size: 20)
+            .scaledFont(name: "Mulish-Bold", size: 26)
     }
 }
 
 struct SemiBoldSmallFont: ViewModifier {
+    var size: CGFloat
+
     func body(content: Content) -> some View {
         content
-            .scaledFont(name: "Mulish-SemiBold", size: 12)
+            .scaledFont(name: "Mulish-SemiBold", size: size)
     }
 }
 
@@ -40,7 +42,7 @@ extension View {
         modifier(BoldLargeFont())
     }
 
-    func semiBoldSmallFont() -> some View {
-        modifier(SemiBoldSmallFont())
+    func semiBoldSmallFont(size: CGFloat = 12) -> some View {
+        modifier(SemiBoldSmallFont(size: size))
     }
 }

--- a/Teacher Workout/Features/Lessons/View/LessonIntroView.swift
+++ b/Teacher Workout/Features/Lessons/View/LessonIntroView.swift
@@ -40,7 +40,7 @@ struct LessonIntroView: View {
                     Image(systemName: "clock")
                     Text(lesson.duration)
                 }
-                .semiBoldSmallFont()
+                .semiBoldSmallFont(size: 14)
                 .foregroundColor(Color("AccentColor"))
                 .padding(6)
 

--- a/Teacher Workout/Utils/Extensions/Text+Styling.swift
+++ b/Teacher Workout/Utils/Extensions/Text+Styling.swift
@@ -6,7 +6,6 @@ extension Text {
         font(Font.custom("Mulish-Regular", size: 15))
             .fontWeight(.bold)
             .tracking(1.25)
-            .foregroundColor(.white)
             .textCase(.uppercase)
             .padding()
             .frame(maxWidth: .infinity)
@@ -14,15 +13,17 @@ extension Text {
 
     func primaryButtonStyle() -> some View {
         baseButtonStyle()
+            .foregroundColor(.white)
             .background(Color.accentColor)
             .mask(RoundedRectangle(cornerRadius: 50, style: .continuous))
     }
 
     func secondaryButtonStyle() -> some View {
         baseButtonStyle()
+            .foregroundColor(Color("neutral"))
             .overlay(
                 RoundedRectangle(cornerRadius: 50)
-                    .stroke(Color.accentColor, lineWidth: 1)
+                    .stroke(Color("neutral"), lineWidth: 1)
             )
     }
 


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #49  

Adjust intro lesson screen layout.

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->

1. Run the iOS app
2. Sign in
3. Go to Home and select a lesson
4. Check the layout is as in Figma

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-28 at 16 33 44](https://user-images.githubusercontent.com/481425/131219693-ca4be23e-0039-4d04-bcb6-05b33fe21996.png)